### PR TITLE
Run nightly builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,8 @@ on:
   pull_request:
     branches:
       - master
+  schedule:
+    - cron: '0 0 * * *' # Run every day at midnight
 
 jobs:
   build:


### PR DESCRIPTION
From time to time, the dependencies for generated projects will be updated in such a way that generates an unbuildable project. Running a nightly build on this generator will ensure that this situation can be caught and remedied quickly.